### PR TITLE
fix(openssl) add support for OpenSSL 3.x releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
         openresty: [1.19.9.1]
         openssl: [1.0.2u, 1.1.1l]
         include:
+          - os: ubuntu-latest
+            openresty: 1.27.1.1
+            openssl: 3.0.15
+
           - os: macos-latest
             openresty: 1.19.9.1
             openssl: 1.1.1l
@@ -129,6 +133,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         openresty:
+          - 1.27.1.1
+          - 1.25.3.2
+          - 1.21.4.3
           - 1.19.9.1
           - 1.15.8.3
           - 1.13.6.2
@@ -161,7 +168,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        openresty: [1.19.9.1]
+        openresty: [1.19.9.1, 1.27.1.1]
     steps:
       - uses: actions/checkout@v2
       - name: Build OpenResty

--- a/src/openssl.js
+++ b/src/openssl.js
@@ -4,32 +4,17 @@ const core = require("@actions/core")
 const { sh, download } = require("./tools")
 
 const OPENSSL_HOST="https://www.openssl.org"
-const GITHUB_HOST="https://github.com"
 
 async function setup_openssl(openssl_version) {
     let arr = openssl_version.match(/(?<semver>(?<maj>\d)\.(?<min>\d)(?:\.(?<patch>\d))?)-?(?<suffix>\S*)/)
-    if (!arr) {
+    if (!arr || (arr.groups.maj != 1 && arr.groups.maj != 3)) {
         return core.setFailed(`Unsupported OpenSSL version: ${openssl_version}`)
     }
 
     let openssl = arr.groups
     openssl.version = arr[0]
 
-    let openssl_url
-
-    switch (openssl.maj) {
-        case "1":
-            openssl_url = `${OPENSSL_HOST}/source/old/${openssl.semver}/openssl-${openssl.version}.tar.gz`
-            break;
-
-        case "3":
-            openssl_url = `${GITHUB_HOST}/openssl/openssl/releases/download/openssl-${openssl.version}/openssl-${openssl.version}.tar.gz`
-            break;
-
-        default:
-            return core.setFailed(`Unsupported OpenSSL version: ${openssl_version}`)
-    }
-
+    let openssl_url = `${OPENSSL_HOST}/source/old/${openssl.semver}/openssl-${openssl.version}.tar.gz`
     let openssl_src = await download("OpenSSL", openssl_url, openssl_version)
 
     try {


### PR DESCRIPTION
OpenResty 1.27.1.1 [targets OpenSSL 3.0.15](https://openresty.org/en/ann-1027001001.html), so this unblocks me adding it to my testing matrices.

Not sure what kind of testing might need to be done, but you can view a successful build from this fork targeting multiple resty versions [here](https://github.com/flrgh/rusty-cli/actions/runs/12919150476).

Edit: I updated the test matrix for 1.27.1.1/3.0.15 but have not run the workflow myself, so it might need some tweaking.